### PR TITLE
Fix jonschlinkert/delete-empty#2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ Given the following directory structure, the **highlighted directories** would b
 ```diff
 foo/
 └─┬ a/
--  ├── aa/
-  ├── bb/
+- ├── aa/
+  ├─┬ bb/
   │ └─┬ bbb/
   │   ├── one.txt
   │   └── two.txt
--  ├── cc/
--  ├ b/
--  └ c/
+- ├─┬ cc/
+- │ └── ccc/
+- ├ b/
+- └ c/
 ```
 
 **async**

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function deleteEmpty(cwd, options, cb) {
       err.code = 'glob';
       return cb(err);
     }
-    utils.async.reduce(files, [], function(acc, filename, next) {
+    utils.async.reduceRight(files, [], function(acc, filename, next) {
       var dir = path.join(cwd, filename);
 
       utils.empty(dir, function(err, isEmpty) {

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,7 @@ describe('deleteEmpty', function() {
     it('should delete nested directories', function(cb) {
       deleteEmpty('test/temp', function(err, deleted) {
         if (err) return cb(err);
+        assert(!fs.existsSync('test/temp/a/aa/aaa/aaaa'));
         assert(!fs.existsSync('test/temp/a/aa/aaa'));
         assert(!fs.existsSync('test/temp/b'));
         assert(!fs.existsSync('test/temp/c'));
@@ -41,7 +42,12 @@ describe('deleteEmpty', function() {
     it('should return the array of deleted directories', function(cb) {
       deleteEmpty('test/temp', function(err, deleted) {
         if (err) return cb(err);
-        assert.deepEqual(deleted, ['test/temp/a/aa/aaa/', 'test/temp/b/', 'test/temp/c/']);
+        assert.deepEqual(deleted.sort(), [
+          'test/temp/a/aa/aaa/aaaa/',
+          'test/temp/a/aa/aaa/',
+          'test/temp/b/',
+          'test/temp/c/'
+        ].sort());
         cb();
       });
     });
@@ -56,6 +62,7 @@ describe('deleteEmpty', function() {
 
     it('should delete nested directories', function(cb) {
       deleteEmpty.sync('test/temp');
+      assert(!fs.existsSync('test/temp/a/aa/aaa/aaaa'));
       assert(!fs.existsSync('test/temp/a/aa/aaa'));
       assert(!fs.existsSync('test/temp/b'));
       assert(!fs.existsSync('test/temp/c'));
@@ -64,7 +71,12 @@ describe('deleteEmpty', function() {
 
     it('should return the array of deleted directories', function(cb) {
       var deleted = deleteEmpty.sync('test/temp');
-      assert.deepEqual(deleted.sort(), ['test/temp/a/aa/aaa/', 'test/temp/b/', 'test/temp/c/'].sort());
+      assert.deepEqual(deleted.sort(), [
+        'test/temp/a/aa/aaa/aaaa/',
+        'test/temp/a/aa/aaa/',
+        'test/temp/b/',
+        'test/temp/c/'
+      ].sort());
       cb();
     });
   });


### PR DESCRIPTION
This fixes #2.

`deleteEmpty()` now follows the same approach that `deleteEmpty.sync()` already uses, which is to go through the directories returned by `utils.glob()` in reverse order.

Since the directories returned by `utils.glob()` are sorted, this ensures that directories deeper down the  hierarchy are checked for emptiness first and deleted before their parent directories are checked.

Uses [`async.reduceRight()`](https://github.com/caolan/async/blob/85832402c8ca199a1a644932c58b86fc38d6596d/README.md#reduceRight) to reverse the order.
