### PR TITLE
Remove .DS_Store from files array so empty folders will be deleted on…

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -23,6 +23,8 @@ function tryReaddir(dir) {
 
 utils.empty = function(dir, cb) {
   fs.readdir(dir, function(err, files) {
+    // Ignore .DS_Store on MacOS
+    files.splice(files.indexOf('.DS_Store'), 1);
     if (err) {
       // if it doesn't exist, we don't
       // need to do anything


### PR DESCRIPTION
Little fix to remove .DS_Store from files array so empty folders will be deleted on MacOS as well.
